### PR TITLE
Breaking the kotlin test

### DIFF
--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
@@ -110,14 +110,10 @@ class KotlinCoroutineInstrumentationTest extends AgentTestRunner {
     expect:
     assertTraces(1) {
       trace(expectedNumberOfSpans, true) {
-        span(4) {
-          operationName "trace.annotation"
-          parent()
-        }
         def topLevelSpan = span(3)
         span(3) {
           operationName "top-level"
-          childOf span(4)
+          parent()
         }
         span(2) {
           operationName "synchronous-child"

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/test/kotlin/KotlinCoroutineTests.kt
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/test/kotlin/KotlinCoroutineTests.kt
@@ -193,11 +193,11 @@ class KotlinCoroutineTests(private val dispatcher: CoroutineDispatcher) {
             }
           }
         }.run(jobs::add)
-
-        jobs.forEach { job -> job.start() }
-        beforeFirstJobStartedMutex.unlock()
-        jobs.awaitAll()
       }
+
+      jobs.forEach { job -> job.start() }
+      beforeFirstJobStartedMutex.unlock()
+      jobs.awaitAll()
 
       4
     }


### PR DESCRIPTION
This changes the `"kotlin suspension should not mess up traces"()` test to create the coroutines _lazily_, and then start them outside the `top-level` span. This breaks up the trace into 2 traces since there is no continuation between the `top-level` span and the coroutines that later will activate the already finished span.
